### PR TITLE
refactor(clipboard-copy): move to more current clipboard api

### DIFF
--- a/src/controller/App.controller.ts
+++ b/src/controller/App.controller.ts
@@ -47,25 +47,25 @@ export default class App extends BaseController {
 		}
 	}
 
-	public async copyLinkToClipboard(_: Event): Promise<void> {
-		const oBundle = <ResourceBundle>(this.getView().getModel("i18n") as ResourceModel).getResourceBundle();
+	public async copyLinkToClipboard(event: Event): Promise<void> {
+		const resourceBundle = <ResourceBundle>(this.getView().getModel("i18n") as ResourceModel).getResourceBundle();
 		try {
+			// try using standard clipboard API
 			if ("clipboard" in navigator) {
 				await navigator.clipboard.writeText(window.location.href);
-				return MessageToast.show(oBundle.getText("app_view_link_copy"));
+				return MessageToast.show(resourceBundle.getText("app_view_link_copy"));
 			}
-			// copy currentHash to clipboard
+			// fallback if clipboard API is not supported
 			const dummy = document.createElement("input");
 			document.body.appendChild(dummy);
 			dummy.setAttribute("value", window.location.href);
 			dummy.select();
 			document.execCommand("copy");
 			document.body.removeChild(dummy);
-			// show message toast
-			MessageToast.show(oBundle.getText("app_view_link_copy"));
+			MessageToast.show(resourceBundle.getText("app_view_link_copy"));
 		} catch (error) {
 			console.error(error);
-			MessageToast.show(oBundle.getText("app_view_link_copy_failed"));
+			MessageToast.show(resourceBundle.getText("app_view_link_copy_failed"));
 		}
 	}
 

--- a/src/controller/App.controller.ts
+++ b/src/controller/App.controller.ts
@@ -1,5 +1,7 @@
+import ResourceBundle from "sap/base/i18n/ResourceBundle";
 import MessageToast from "sap/m/MessageToast";
 import Event from "sap/ui/base/Event";
+import ResourceModel from "sap/ui/model/resource/ResourceModel";
 import BaseController from "./BaseController";
 import QueryUtil from "./QueryUtil";
 
@@ -45,9 +47,13 @@ export default class App extends BaseController {
 		}
 	}
 
-	public copyLinkToClipboard(event: Event): void {
-		const oBundle = this.getView().getModel("i18n").getResourceBundle();
+	public async copyLinkToClipboard(_: Event): Promise<void> {
+		const oBundle = <ResourceBundle>(this.getView().getModel("i18n") as ResourceModel).getResourceBundle();
 		try {
+			if ("clipboard" in navigator) {
+				await navigator.clipboard.writeText(window.location.href);
+				return MessageToast.show(oBundle.getText("app_view_link_copy"));
+			}
 			// copy currentHash to clipboard
 			const dummy = document.createElement("input");
 			document.body.appendChild(dummy);
@@ -63,7 +69,7 @@ export default class App extends BaseController {
 		}
 	}
 
-		/**
+	/**
 	 * Remove the Splash screen after the application has been loaded!
 	 */
 	public onAfterRendering(): void {


### PR DESCRIPTION
Hey @marianfoo 

I recently saw that you added the feature to copy the current path to the clipboard. I see that the UI5 sdk does it the same way, however there is a more common/modern way to do this as usage of document.execCommand is deprecated and should probably only be used as fallback.

- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
- https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand

I checked out how github itself does this when hovering over a piece of code and they too use this only as fallback. :) 

The way it is currently implemented the `execCommand` is a fallback in case the clipboard api is not available. I could probably wrap this in it's own try-catch to also have `execCommand` as fallback in case the clipboard API fails (which is unlikely though).

BR,
Marco