### PR TITLE
feat: refactor type icons on List Item

### DIFF
--- a/src/control/PackageListItemContent.control.xml
+++ b/src/control/PackageListItemContent.control.xml
@@ -38,10 +38,6 @@
         <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/window-maximize" />
         <tnt:InfoLabel id="trend-item-type" class="sapUiTinyMarginEnd" text="{$this>type}" renderMode="Narrow" colorScheme="2" displayOnly="false" />
 
-        <!-- <tnt:InfoLabel id="trend-item-tag3" class="sapUiTinyMarginEnd" text=" STARS {$this>stars}" renderMode="Narrow" colorScheme="5" displayOnly="false" visible="{= !!${$this>stars} }" />
-
-        <tnt:InfoLabel id="trend-item-tag1" class="sapUiTinyMarginEnd" text="FORKS {$this>forks}" renderMode="Narrow" colorScheme="5" displayOnly="false" visible="{= !!${$this>forks} }" /> -->
-
         <tnt:InfoLabel
           id="downloads14"
           class="sapUiTinyMarginEnd"
@@ -150,15 +146,5 @@
         />
       </HBox>
     </VBox>
-    <!-- <VBox visible="{= ${device>/system/desktop} === true }">
-      <core:Icon visible="{= ${$this>type} === 'module'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/code" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'middleware' }" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/server" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'task'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/list-check" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'customControl'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/gamepad" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'generator'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/robot" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'tooling'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/screwdriver" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'vscode'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons/microsoft" size="70px" />
-      <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/window-maximize" size="70px" />
-    </VBox> -->
   </FlexBox>
 </core:FragmentDefinition>

--- a/src/control/PackageListItemContent.control.xml
+++ b/src/control/PackageListItemContent.control.xml
@@ -28,6 +28,14 @@
 
       <FormattedText id="trend-desc" htmlText="{$this>description}" />
       <HBox id="trend-item-tags-box" class="sapUiTinyMarginTop" wrap="Wrap">
+        <core:Icon visible="{= ${$this>type} === 'module'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/code" />
+        <core:Icon visible="{= ${$this>type} === 'middleware' }" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/server" />
+        <core:Icon visible="{= ${$this>type} === 'task'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/list-check" />
+        <core:Icon visible="{= ${$this>type} === 'customControl'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/gamepad" />
+        <core:Icon visible="{= ${$this>type} === 'generator'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/robot" />
+        <core:Icon visible="{= ${$this>type} === 'tooling'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/screwdriver" />
+        <core:Icon visible="{= ${$this>type} === 'vscode'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons/microsoft" />
+        <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/window-maximize" />
         <tnt:InfoLabel id="trend-item-type" class="sapUiTinyMarginEnd" text="{$this>type}" renderMode="Narrow" colorScheme="2" displayOnly="false" />
 
         <!-- <tnt:InfoLabel id="trend-item-tag3" class="sapUiTinyMarginEnd" text=" STARS {$this>stars}" renderMode="Narrow" colorScheme="5" displayOnly="false" visible="{= !!${$this>stars} }" />
@@ -142,7 +150,7 @@
         />
       </HBox>
     </VBox>
-    <VBox visible="{= ${device>/system/desktop} === true }">
+    <!-- <VBox visible="{= ${device>/system/desktop} === true }">
       <core:Icon visible="{= ${$this>type} === 'module'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/code" size="70px" />
       <core:Icon visible="{= ${$this>type} === 'middleware' }" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/server" size="70px" />
       <core:Icon visible="{= ${$this>type} === 'task'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/list-check" size="70px" />
@@ -151,6 +159,6 @@
       <core:Icon visible="{= ${$this>type} === 'tooling'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/screwdriver" size="70px" />
       <core:Icon visible="{= ${$this>type} === 'vscode'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons/microsoft" size="70px" />
       <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiSmallMarginBegin sapUiResponsiveContentPadding" src="sap-icon://font-awesome-icons-solid/window-maximize" size="70px" />
-    </VBox>
+    </VBox> -->
   </FlexBox>
 </core:FragmentDefinition>

--- a/src/control/PackageListItemContent.control.xml
+++ b/src/control/PackageListItemContent.control.xml
@@ -28,14 +28,14 @@
 
       <FormattedText id="trend-desc" htmlText="{$this>description}" />
       <HBox id="trend-item-tags-box" class="sapUiTinyMarginTop" wrap="Wrap">
-        <core:Icon visible="{= ${$this>type} === 'module'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/code" />
-        <core:Icon visible="{= ${$this>type} === 'middleware' }" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/server" />
-        <core:Icon visible="{= ${$this>type} === 'task'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/list-check" />
-        <core:Icon visible="{= ${$this>type} === 'customControl'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/gamepad" />
-        <core:Icon visible="{= ${$this>type} === 'generator'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/robot" />
-        <core:Icon visible="{= ${$this>type} === 'tooling'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/screwdriver" />
-        <core:Icon visible="{= ${$this>type} === 'vscode'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons/microsoft" />
-        <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiTinyMarginEnd" src="sap-icon://font-awesome-icons-solid/window-maximize" />
+        <core:Icon visible="{= ${$this>type} === 'module'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/code" />
+        <core:Icon visible="{= ${$this>type} === 'middleware' }" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/server" />
+        <core:Icon visible="{= ${$this>type} === 'task'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/list-check" />
+        <core:Icon visible="{= ${$this>type} === 'customControl'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/gamepad" />
+        <core:Icon visible="{= ${$this>type} === 'generator'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/robot" />
+        <core:Icon visible="{= ${$this>type} === 'tooling'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/screwdriver" />
+        <core:Icon visible="{= ${$this>type} === 'vscode'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons/microsoft" />
+        <core:Icon visible="{= ${$this>type} === 'application'}" class="sapUiTinyMarginEnd typeIconsLineItem" src="sap-icon://font-awesome-icons-solid/window-maximize" />
         <tnt:InfoLabel id="trend-item-type" class="sapUiTinyMarginEnd" text="{$this>type}" renderMode="Narrow" colorScheme="2" displayOnly="false" />
 
         <!-- <tnt:InfoLabel id="trend-item-tag3" class="sapUiTinyMarginEnd" text=" STARS {$this>stars}" renderMode="Narrow" colorScheme="5" displayOnly="false" visible="{= !!${$this>stars} }" />

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -130,3 +130,9 @@
 .sapUxAPObjectPageSection:focus {
 	box-shadow: none !important;
 }
+/*
+ * style type icons
+ */
+.typeIconsLineItem {
+	color: #d11212;
+}


### PR DESCRIPTION
# Changes
- remove icon on the side
- set icon before infolabel 'type'
- make icon same color as type infolabel

# Screenshots
## light
![image](https://user-images.githubusercontent.com/13335743/174021389-54585b9b-2849-404c-b835-705a50b6e8b8.png)
![image](https://user-images.githubusercontent.com/13335743/174021491-d2497bdb-1a36-4997-b233-2d52ab6f057d.png)
## dark
![image](https://user-images.githubusercontent.com/13335743/174021611-00a9b670-829f-433a-8f7e-31e2508efd9d.png)
![image](https://user-images.githubusercontent.com/13335743/174021572-5b2b009b-dd8e-43ba-ba0a-c89d098dabd7.png)
