### PR TITLE
feat: filter packages from hot packages without npm

### DIFF
--- a/src/view/HotPackages.view.xml
+++ b/src/view/HotPackages.view.xml
@@ -5,17 +5,18 @@
     mode="None"
     growing="true"
     growingScrollToLoad="true"
-    items="{path: 'data>/packages/', sorter : { path : 'downloadsFortnightGrowth',descending: 'false' },
-    filters: [
-      {
-        filters : [
-            { path : 'type', operator : 'NE', value1 : 'generator'},
-            { path : 'type', operator : 'NE', value1 : 'application'},
-            { path : 'type', operator : 'NE', value1 : 'vscode'}
-        ], and :true
-}
-        ]
-  }"
+    items="{
+      path: 'data>/packages/', 
+      sorter : { path : 'downloadsFortnightGrowth',descending: 'false' },
+      filters: [{
+          filters : [
+              { path : 'type', operator : 'NE', value1 : 'generator'},
+              { path : 'type', operator : 'NE', value1 : 'application'},
+              { path : 'type', operator : 'NE', value1 : 'vscode'}
+          ], 
+          and :true
+      }]
+    }"
     width="{= ${device>/system/phone} === true ? '' : '1024px' }"
   >
     <CustomListItem id="_IDGenCustomListItem1" type="Navigation" press="onPress">

--- a/src/view/HotPackages.view.xml
+++ b/src/view/HotPackages.view.xml
@@ -6,8 +6,14 @@
     growing="true"
     growingScrollToLoad="true"
     items="{path: 'data>/packages/', sorter : { path : 'downloadsFortnightGrowth',descending: 'false' },
+    filters: [
+      {
         filters : [
-            { path : 'type', operator : 'NE', value1 : 'generator'}
+            { path : 'type', operator : 'NE', value1 : 'generator'},
+            { path : 'type', operator : 'NE', value1 : 'application'},
+            { path : 'type', operator : 'NE', value1 : 'vscode'}
+        ], and :true
+}
         ]
   }"
     width="{= ${device>/system/phone} === true ? '' : '1024px' }"


### PR DESCRIPTION
since the calculation of "hot" depends on npm downloads growth, we need to exclude packages without npm
currently these are:
- generators
- application
- vscode