### PR TITLE
feat: save scroll state for each view

### DIFF
--- a/.github/workflows/wdi5-test.yml
+++ b/.github/workflows/wdi5-test.yml
@@ -42,14 +42,14 @@ jobs:
         run: |
           npm i
 
-      # run app
+      # build things
+      - name: build
+        run: npm run build
+
+      # run appp
       - name: run app
         run: npm run start:test&
 
       # run wdi5 tests
       - name: test wdi5 core
         run: npm run test
-
-      # build things
-      - name: build
-        run: npm run build

--- a/.github/workflows/wdi5-test.yml
+++ b/.github/workflows/wdi5-test.yml
@@ -42,14 +42,14 @@ jobs:
         run: |
           npm i
 
-      # build things
-      - name: build
-        run: npm run build
-
-      # run appp
+      # run app
       - name: run app
         run: npm run start:test&
 
       # run wdi5 tests
       - name: test wdi5 core
         run: npm run test
+
+      # build things
+      - name: build
+        run: npm run build

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -61,7 +61,13 @@ export default class Component extends UIComponent {
 			tagFilter: "tag",
 		});
 		this.setModel(settingsModel, "settings");
-
+		const scrollStateModel = new JSONModel({
+			packages: 0,
+			tags: 0,
+			timeline: 0,
+			contributors: 0,
+		});
+		this.setModel(scrollStateModel, "scrollState");
 		this.getRouter().attachRouteMatched(this.onBeforeRouteMatched, this);
 
 		// set the device model

--- a/src/controller/AllPackages.controller.ts
+++ b/src/controller/AllPackages.controller.ts
@@ -55,14 +55,7 @@ export default class AllPackages extends AppController {
 		// get object name from oevent
 		const objectName = event.getSource().getBindingContext("data").getObject().name;
 		//route to object view
-		this.navTo(
-			"RouteObjectView",
-			{
-				name: objectName,
-			},
-			null,
-			"object"
-		);
+		this.navTo("RouteObjectView", { name: objectName }, null, "object");
 	}
 
 	public onSortSelectChange(event: Event): void {
@@ -90,18 +83,5 @@ export default class AllPackages extends AppController {
 	private onSelectionChange(event: Event): void {
 		this.queryUtil.onSelectionChange(event);
 		this.applySearchFilter();
-	}
-
-	private onSearch(event: Event): void {
-		console.log("onSearch");
-	}
-	private onSearchLiveChange(event: Event): void {
-		console.log("onSearchLiveChange");
-	}
-	private onSearchChange(event: Event): void {
-		console.log("onSearchChange");
-	}
-	private onSuggest(event: Event): void {
-		console.log("onSuggest");
 	}
 }

--- a/src/controller/AllPackages.controller.ts
+++ b/src/controller/AllPackages.controller.ts
@@ -31,6 +31,7 @@ export default class AllPackages extends AppController {
 	}
 
 	public onPatternMatched(event: Event): void {
+		this.getView().getParent().getParent().getParent().scrollTo(this.getView().getModel("scrollState").getProperty("/packages"));
 		this.getView().getModel("settings").setProperty("/headerKey", "allPackages");
 		this.applySearchFilter();
 	}
@@ -54,9 +55,14 @@ export default class AllPackages extends AppController {
 		// get object name from oevent
 		const objectName = event.getSource().getBindingContext("data").getObject().name;
 		//route to object view
-		this.navTo("RouteObjectView", {
-			name: objectName,
-		});
+		this.navTo(
+			"RouteObjectView",
+			{
+				name: objectName,
+			},
+			null,
+			"object"
+		);
 	}
 
 	public onSortSelectChange(event: Event): void {
@@ -84,5 +90,18 @@ export default class AllPackages extends AppController {
 	private onSelectionChange(event: Event): void {
 		this.queryUtil.onSelectionChange(event);
 		this.applySearchFilter();
+	}
+
+	private onSearch(event: Event): void {
+		console.log("onSearch");
+	}
+	private onSearchLiveChange(event: Event): void {
+		console.log("onSearchLiveChange");
+	}
+	private onSearchChange(event: Event): void {
+		console.log("onSearchChange");
+	}
+	private onSuggest(event: Event): void {
+		console.log("onSuggest");
 	}
 }

--- a/src/controller/App.controller.ts
+++ b/src/controller/App.controller.ts
@@ -36,7 +36,7 @@ export default class App extends BaseController {
 	public applySearch(): void {
 		if (!this.getRouter().getHashChanger().getHash().startsWith("packages")) {
 			this.getView().getModel("settings").setProperty("/headerKey", "allPackages");
-			this.navTo("allPackages");
+			this.navTo("allPackages", null, null, this.getRouter().getHashChanger().getHash());
 		} else {
 			this.getOwnerComponent().byId("AllPackages").getController().applySearchFilter();
 		}

--- a/src/controller/BaseController.ts
+++ b/src/controller/BaseController.ts
@@ -9,6 +9,7 @@ import History from "sap/ui/core/routing/History";
 import UI5Event from "sap/ui/base/Event";
 import JSONModel from "sap/ui/model/json/JSONModel";
 import formatter from "../model/formatter";
+import Page from "sap/m/Page";
 
 /**
  * @namespace org.openui5.bestofui5.controller
@@ -113,20 +114,12 @@ export default abstract class BaseController extends Controller {
 			return this.getView().byId("page").getScrollDelegate().getScrollTop();
 		} catch (error) {
 			try {
-				return this.getView().getParent().getParent().getParent().getScrollDelegate().getScrollTop();
+				return (sap.ui.getCore().byId("__component0---rootView--page") as Page).getScrollDelegate().getScrollTop();
 			} catch (error) {
 				try {
-					return this.getView().getParent().getParent().getScrollDelegate().getScrollTop();
+					return this.getView().getParent().getParent().getParent().getScrollDelegate().getScrollTop();
 				} catch (error) {
-					try {
-						return this.getView().getParent().getScrollDelegate().getScrollTop();
-					} catch (error) {
-						try {
-							return this.getView().getScrollDelegate().getScrollTop();
-						} catch (error) {
-							return 0;
-						}
-					}
+					console.info("no scroll delegate");
 				}
 			}
 		}

--- a/src/controller/BaseController.ts
+++ b/src/controller/BaseController.ts
@@ -66,7 +66,10 @@ export default abstract class BaseController extends Controller {
 	 * @param [oParameters] Navigation parameters
 	 * @param [bReplace] Defines if the hash should be replaced (no browser history entry) or set (browser history entry)
 	 */
-	public navTo(sName: string, oParameters?: object, bReplace?: boolean): void {
+	public navTo(sName: string, oParameters?: object, bReplace?: boolean, source?: string): void {
+		if (source !== "object") {
+			this.getView().getModel("scrollState").setProperty(`/${source}`, this.getScrollTop());
+		}
 		// replace slash in package name because it cant be in url
 		try {
 			oParameters.name = oParameters.name.replace("/", "_");
@@ -92,6 +95,40 @@ export default abstract class BaseController extends Controller {
 
 	public onButtonHeaderSelect(event: UI5Event, headerKey: string): void {
 		(this.getView().getModel("settings") as JSONModel).setProperty("/headerKey", headerKey);
-		this.navTo(headerKey);
+		let sourceHash = this.getRouter().getHashChanger().getHash();
+		// make clear what the current view is
+		sourceHash = sourceHash.split("?")[0];
+		if (sourceHash.indexOf("/") > -1) {
+			sourceHash = "object";
+		}
+		if (sourceHash === "") {
+			sourceHash = "hot";
+		}
+		// sourceHash = sourceHash.substring(0, sourceHash.indexOf('?'))
+		this.navTo(headerKey, null, null, sourceHash);
+	}
+
+	private getScrollTop(): number {
+		try {
+			return this.getView().byId("page").getScrollDelegate().getScrollTop();
+		} catch (error) {
+			try {
+				return this.getView().getParent().getParent().getParent().getScrollDelegate().getScrollTop();
+			} catch (error) {
+				try {
+					return this.getView().getParent().getParent().getScrollDelegate().getScrollTop();
+				} catch (error) {
+					try {
+						return this.getView().getParent().getScrollDelegate().getScrollTop();
+					} catch (error) {
+						try {
+							return this.getView().getScrollDelegate().getScrollTop();
+						} catch (error) {
+							return 0;
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/controller/Contributors.controller.ts
+++ b/src/controller/Contributors.controller.ts
@@ -12,5 +12,6 @@ export default class Timeline extends BaseController {
 
 	public onPatternMatched(event: Event): void {
 		(this.getView().getModel("settings") as JSONModel).setProperty("/headerKey", "contributors");
+		this.getView().getParent().getParent().getParent().scrollTo(this.getView().getModel("scrollState").getProperty("/contributors"));
 	}
 }

--- a/src/controller/HotPackages.controller.ts
+++ b/src/controller/HotPackages.controller.ts
@@ -11,6 +11,7 @@ export default class HotPackages extends AppController {
 
 	public onPatternMatched(event: Event): void {
 		(this.getView().getModel("settings") as JSONModel).setProperty("/headerKey", "hotPackages");
+		this.getView().getParent().getParent().getParent().scrollTo(this.getView().getModel("scrollState").getProperty("/hot"));
 	}
 	public onPress(event: Event): void {
 		// get object name from oevent

--- a/src/controller/Object.controller.ts
+++ b/src/controller/Object.controller.ts
@@ -30,6 +30,7 @@ export default class Object extends BaseController {
 			path: `/packages/${objectIndex}`,
 			model: "data",
 		});
+		this.getView().getParent().getParent().getParent().scrollTo(0);
 	}
 
 	public onPressStandardListItemNpmLink(event: Event): void {

--- a/src/controller/Tags.controller.ts
+++ b/src/controller/Tags.controller.ts
@@ -14,6 +14,7 @@ export default class Tags extends AppController {
 
 	public onPatternMatched(event: Event): void {
 		(this.getView().getModel("settings") as JSONModel).setProperty("/headerKey", "tags");
+		this.getView().getParent().getParent().getParent().scrollTo(this.getView().getModel("scrollState").getProperty("/tags"));
 	}
 
 	public onSelectionChange(event: Event): void {
@@ -42,6 +43,7 @@ export default class Tags extends AppController {
 
 		(this.getView().getModel("settings") as JSONModel).setProperty("/tokens", tokenArray);
 		(this.getView().getModel("settings") as JSONModel).setProperty("/search", "");
+		this.getView().getModel("scrollState").setProperty(`/packages`, 0);
 		this.applySearch();
 	}
 }

--- a/src/controller/Timeline.controller.ts
+++ b/src/controller/Timeline.controller.ts
@@ -18,5 +18,6 @@ export default class Timeline extends BaseController {
 
 	public onPatternMatched(event: Event): void {
 		(this.getView().getModel("settings") as JSONModel).setProperty("/headerKey", "timeline");
+		this.getView().getParent().getParent().getParent().scrollTo(this.getView().getModel("scrollState").getProperty("/timeline"));
 	}
 }


### PR DESCRIPTION
# Changes
- new json model for each scroll top value y for each view
- on `navTo` in basecontroller, scroll state is saved for each view
- in `onPatternMatched` the state from JsonModel will be read and set
- object view will be alway on top and not saved
- from tags view filtering to all packages will be always on top

Thanks @wridgeu for your suggestion, i hacked a little around.
WDYT?
![Animation](https://user-images.githubusercontent.com/13335743/177005816-4192c402-61ed-4787-9cce-d5c696566a51.gif)

