### PR TITLE
fix: check for repo owner on azure static web apps deployment

### DIFF
--- a/.github/workflows/azure_static_create.yml
+++ b/.github/workflows/azure_static_create.yml
@@ -3,11 +3,11 @@ name: Create Static Web App on Azure
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [labeled, opened]
 
 jobs:
   build-and-deploy:
-    if: ${{ github.event.label.name == 'deploy_test' }}
+    if: ${{ github.event.label.name == 'deploy_test' && github.repository_owner == 'ui5-community' }}
     runs-on: ubuntu-latest
     steps:
       - name: format branch name

--- a/.github/workflows/azure_static_delete.yml
+++ b/.github/workflows/azure_static_delete.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   delete:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'deploy_test') }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'deploy_test') && github.repository_owner == 'ui5-community' }}
     runs-on: ubuntu-latest
     steps:
       - name: format branch name

--- a/.github/workflows/azure_static_update.yml
+++ b/.github/workflows/azure_static_update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-deploy:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'deploy_test') }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'deploy_test') && github.repository_owner == 'ui5-community' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check PR labels action step

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ The packages are crawled from are located in [`sources.json`](https://github.com
 ### Deployment of Pull Requests to Azure Static Web Apps
 
 In order for contributors to better understand the impact of a pull request and to better test it, there is an option to deploy the changes of a pull request into a test environment, using [Azure Static Web Apps](https://azure.microsoft.com/en-en/services/app-service/static/#overview).  
-This makes it easy to access and test the app.
+This makes it easy to access and test the app.  
+**For security reasons, this only works for pull requests from the `ui5-community` repo.**
 
 #### How To
 

--- a/README.md
+++ b/README.md
@@ -164,3 +164,4 @@ View the [Changelog here](CHANGELOG.md)
 ## License
 
 This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](LICENSE) file.
+


### PR DESCRIPTION
For security reasons, you can not access the secrets from the `ui5-community` repo when the owner of a pull request is not the `ui5-community`
To prevent running into a error, the gh action will check for the owner