### PR TITLE
feat: add live demo url to object page

### DIFF
--- a/.github/workflows/create_demo_apps.yml
+++ b/.github/workflows/create_demo_apps.yml
@@ -1,0 +1,60 @@
+name: Create Demo Apps
+
+on:
+  workflow_dispatch:
+
+jobs:
+  openui5-sample-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tools repo
+        uses: actions/checkout@v3
+        with:
+          repository: SAP/openui5-sample-app
+      - name: use node 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build-self-contained
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.azuresecret_openui5_sample_app }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          skip_api_build: true
+          skip_app_build: true
+          app_location: "dist" # App source code path
+          output_location: "" # Built app content directory - optional
+          is_static_export: true
+  ui5-typescript-helloworld:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tools repo
+        uses: actions/checkout@v3
+        with:
+          repository: SAP-samples/ui5-typescript-helloworld
+      - name: use node 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build:opt
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.azuresecret_ui5_typescript_helloworld }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          skip_api_build: true
+          skip_app_build: true
+          app_location: "dist" # App source code path
+          output_location: "" # Built app content directory - optional
+          is_static_export: true

--- a/src/i18n/i18n_en.properties
+++ b/src/i18n/i18n_en.properties
@@ -52,6 +52,7 @@ object_view_header_license=License
 object_view_header_github=GitHub
 object_view_header_npm=NPM
 object_view_header_microsoft=VisualStudio Marketplace
+object_view_header_livedemo=Live Demo
 object_view_header_downloads365=Downloads last 365 days
 object_view_header_downloads30=Downloads last 30 days
 object_view_header_downloads14=Downloads last 14 days

--- a/src/view/Object.view.xml
+++ b/src/view/Object.view.xml
@@ -32,6 +32,10 @@
           <core:Icon src="sap-icon://font-awesome-icons/microsoft" class="sapUiSmallMarginEnd" />
           <m:Link text="{i18n>object_view_header_microsoft}" href="{data>vscodelink}" target="_blank" />
         </m:HBox>
+        <m:HBox visible="{= !!${data>liveDemoUrl}}">
+          <core:Icon src="sap-icon://internet-browser" class="sapUiSmallMarginEnd" />
+          <m:Link text="{i18n>object_view_header_livedemo}" href="{data>liveDemoUrl}" target="_blank" />
+        </m:HBox>
         <m:layoutData>
           <m:FlexItemData growFactor="1" />
         </m:layoutData>


### PR DESCRIPTION
# Changes
- with a github workflow we can manually deploy demo apps to a azure statice web app
- the live demo url can be added to the `source.json`
- if a liveDemoUrl is present show this url on object page

## What do to if you want to add a sample app

1. create azure static web app
2. create subdomain
3. connect subdomain with azure static web app
4. add livedemourl to `source.json`
5. add build step to `create_demo_apps.yml` github workflow
6. run deployment workflow
